### PR TITLE
Add splash screen before main screen

### DIFF
--- a/app/src/main/java/com/example/lairsheet/MainActivity.kt
+++ b/app/src/main/java/com/example/lairsheet/MainActivity.kt
@@ -3,15 +3,27 @@ package com.example.lairsheet
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.*
 import com.example.lairsheet.ui.theme.LairSheetTheme
 import com.example.lairsheet.ui.theme.MainScreen
+import com.example.lairsheet.ui.theme.SplashScreen
+import kotlinx.coroutines.delay
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             LairSheetTheme {
-                MainScreen()
+                var showSplash by remember { mutableStateOf(true) }
+                LaunchedEffect(Unit) {
+                    delay(2000)
+                    showSplash = false
+                }
+                if (showSplash) {
+                    SplashScreen()
+                } else {
+                    MainScreen()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/lairsheet/ui/theme/SplashScreen.kt
+++ b/app/src/main/java/com/example/lairsheet/ui/theme/SplashScreen.kt
@@ -1,0 +1,39 @@
+package com.example.lairsheet.ui.theme
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.lairsheet.R
+
+@Composable
+fun SplashScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(LightPink),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_dragon_logo),
+                contentDescription = "Логотип",
+                modifier = Modifier.size(128.dp)
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = "Lair Sheet",
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+                color = DeepRed
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show a splash screen with centered logo and title before opening the main screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fb2eec45c832ab5332116845bec7a