### PR TITLE
Add splash screen and character creation with version filtering

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -43,12 +44,16 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/lairsheet/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/lairsheet/CharacterViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.lairsheet
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.room.Room
+import com.example.lairsheet.data.AppDatabase
+import com.example.lairsheet.data.Character
+import com.example.lairsheet.data.Ruleset
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+
+class CharacterViewModel(application: Application) : AndroidViewModel(application) {
+    private val dao = Room.databaseBuilder(
+        application,
+        AppDatabase::class.java,
+        "characters.db"
+    ).build().characterDao()
+
+    fun characters(ruleset: Ruleset): Flow<List<Character>> = dao.charactersByRuleset(ruleset)
+
+    fun addCharacter(name: String, subtitle: String, ruleset: Ruleset) {
+        viewModelScope.launch {
+            dao.insert(Character(name = name, subtitle = subtitle, ruleset = ruleset))
+        }
+    }
+}

--- a/app/src/main/java/com/example/lairsheet/MainActivity.kt
+++ b/app/src/main/java/com/example/lairsheet/MainActivity.kt
@@ -3,16 +3,55 @@ package com.example.lairsheet
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.*
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.lairsheet.data.Ruleset
+import com.example.lairsheet.ui.theme.CharacterCreationScreen
 import com.example.lairsheet.ui.theme.LairSheetTheme
 import com.example.lairsheet.ui.theme.MainScreen
+import com.example.lairsheet.ui.theme.SplashScreen
+import kotlinx.coroutines.delay
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             LairSheetTheme {
-                MainScreen()
+                var showSplash by remember { mutableStateOf(true) }
+                val vm: CharacterViewModel = viewModel()
+                var currentScreen by remember { mutableStateOf<Screen>(Screen.Main) }
+                var ruleset by remember { mutableStateOf(Ruleset.R5E_2014) }
+                val characters by vm.characters(ruleset).collectAsState(emptyList())
+                LaunchedEffect(Unit) {
+                    delay(2000)
+                    showSplash = false
+                }
+                if (showSplash) {
+                    SplashScreen()
+                } else {
+                    when (currentScreen) {
+                        Screen.Main -> MainScreen(
+                            ruleset = ruleset,
+                            characters = characters,
+                            onRulesetChange = { ruleset = it },
+                            onCreateCharacter = { currentScreen = Screen.Create }
+                        )
+                        Screen.Create -> CharacterCreationScreen(
+                            ruleset = ruleset,
+                            onSave = { name, subtitle ->
+                                vm.addCharacter(name, subtitle, ruleset)
+                                currentScreen = Screen.Main
+                            },
+                            onCancel = { currentScreen = Screen.Main }
+                        )
+                    }
+                }
             }
         }
     }
+}
+
+private sealed class Screen {
+    data object Main : Screen()
+    data object Create : Screen()
 }

--- a/app/src/main/java/com/example/lairsheet/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/lairsheet/data/AppDatabase.kt
@@ -1,0 +1,11 @@
+package com.example.lairsheet.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(entities = [Character::class], version = 1)
+@TypeConverters(Converters::class)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun characterDao(): CharacterDao
+}

--- a/app/src/main/java/com/example/lairsheet/data/Character.kt
+++ b/app/src/main/java/com/example/lairsheet/data/Character.kt
@@ -1,0 +1,12 @@
+package com.example.lairsheet.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "characters")
+data class Character(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String,
+    val subtitle: String,
+    val ruleset: Ruleset
+)

--- a/app/src/main/java/com/example/lairsheet/data/CharacterDao.kt
+++ b/app/src/main/java/com/example/lairsheet/data/CharacterDao.kt
@@ -1,0 +1,15 @@
+package com.example.lairsheet.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CharacterDao {
+    @Query("SELECT * FROM characters WHERE ruleset = :ruleset")
+    fun charactersByRuleset(ruleset: Ruleset): Flow<List<Character>>
+
+    @Insert
+    suspend fun insert(character: Character)
+}

--- a/app/src/main/java/com/example/lairsheet/data/Converters.kt
+++ b/app/src/main/java/com/example/lairsheet/data/Converters.kt
@@ -1,0 +1,11 @@
+package com.example.lairsheet.data
+
+import androidx.room.TypeConverter
+
+class Converters {
+    @TypeConverter
+    fun fromRuleset(value: Ruleset): String = value.name
+
+    @TypeConverter
+    fun toRuleset(value: String): Ruleset = Ruleset.valueOf(value)
+}

--- a/app/src/main/java/com/example/lairsheet/data/Ruleset.kt
+++ b/app/src/main/java/com/example/lairsheet/data/Ruleset.kt
@@ -1,0 +1,3 @@
+package com.example.lairsheet.data
+
+enum class Ruleset { R5E_2014, R5E_2024 }

--- a/app/src/main/java/com/example/lairsheet/ui/theme/CharacterCreationScreen.kt
+++ b/app/src/main/java/com/example/lairsheet/ui/theme/CharacterCreationScreen.kt
@@ -1,0 +1,73 @@
+package com.example.lairsheet.ui.theme
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.lairsheet.data.Ruleset
+
+@Composable
+fun CharacterCreationScreen(
+    ruleset: Ruleset,
+    onSave: (String, String) -> Unit,
+    onCancel: () -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var subtitle by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Создание персонажа",
+            fontSize = 24.sp,
+            color = DeepRed
+        )
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Имя") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = subtitle,
+            onValueChange = { subtitle = it },
+            label = { Text("Описание") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(16.dp))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Button(
+                onClick = onCancel,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = LightPink,
+                    contentColor = DeepRed
+                ),
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Отмена")
+            }
+            Button(
+                onClick = { onSave(name, subtitle) },
+                enabled = name.isNotBlank(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = DeepRed,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ),
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Сохранить")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/lairsheet/ui/theme/MainScreen.kt
+++ b/app/src/main/java/com/example/lairsheet/ui/theme/MainScreen.kt
@@ -7,13 +7,8 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -24,16 +19,21 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.lairsheet.R
+import com.example.lairsheet.data.Character
+import com.example.lairsheet.data.Ruleset
 
 @Composable
-fun MainScreen() {
-    var ruleset by remember { mutableStateOf(Ruleset.R5E_2014) }
-
+fun MainScreen(
+    ruleset: Ruleset,
+    characters: List<Character>,
+    onRulesetChange: (Ruleset) -> Unit,
+    onCreateCharacter: () -> Unit
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp)
+            .padding(16.dp),
     ) {
         Header()
 
@@ -41,17 +41,17 @@ fun MainScreen() {
 
         RulesToggle(
             selected = ruleset,
-            onSelect = { ruleset = it }
+            onSelect = onRulesetChange
         )
 
         Spacer(Modifier.height(16.dp))
 
-        CreateCharacterButton(onClick = { /* TODO: навигация на создание */ })
+        CreateCharacterButton(onClick = onCreateCharacter)
 
         Spacer(Modifier.height(16.dp))
 
         CharacterGrid(
-            items = demoCharacters
+            items = characters
         )
     }
 }
@@ -64,7 +64,7 @@ private fun Header() {
             .clip(RoundedCornerShape(16.dp))
             .background(LightPink)
             .padding(horizontal = 16.dp, vertical = 14.dp)
-            .fillMaxWidth()
+            .fillMaxWidth(),
     ) {
         Image(
             painter = painterResource(id = R.drawable.ic_dragon_logo),
@@ -81,8 +81,6 @@ private fun Header() {
     }
 }
 
-private enum class Ruleset { R5E_2014, R5E_2024 }
-
 @Composable
 private fun RulesToggle(
     selected: Ruleset,
@@ -98,7 +96,7 @@ private fun RulesToggle(
             onClick = { onSelect(Ruleset.R5E_2014) },
             modifier = Modifier
                 .weight(1f)
-                .height(44.dp)
+                .height(44.dp),
         )
         SegmentedButton(
             text = "D&D5e 24",
@@ -106,7 +104,7 @@ private fun RulesToggle(
             onClick = { onSelect(Ruleset.R5E_2024) },
             modifier = Modifier
                 .weight(1f)
-                .height(44.dp)
+                .height(44.dp),
         )
     }
 }
@@ -154,21 +152,8 @@ private fun CreateCharacterButton(onClick: () -> Unit) {
     }
 }
 
-private data class CharacterCardUi(
-    val name: String,
-    val subtitle: String,
-    val avatarRes: Int = R.drawable.ic_dragon_logo // заглушка
-)
-
-private val demoCharacters = listOf(
-    CharacterCardUi("Elias", "Human Fighter"),
-    CharacterCardUi("Seraphine", "Elf Wizard Lv"),
-    CharacterCardUi("Thorin", "Dwarf Cleric"),
-    CharacterCardUi("Mira", "Tiefling Rogue")
-)
-
 @Composable
-private fun CharacterGrid(items: List<CharacterCardUi>) {
+private fun CharacterGrid(items: List<Character>) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(2),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -182,7 +167,7 @@ private fun CharacterGrid(items: List<CharacterCardUi>) {
 }
 
 @Composable
-private fun CharacterCard(item: CharacterCardUi) {
+private fun CharacterCard(item: Character) {
     Card(
         colors = CardDefaults.cardColors(
             containerColor = LightPink
@@ -200,7 +185,7 @@ private fun CharacterCard(item: CharacterCardUi) {
             verticalArrangement = Arrangement.SpaceBetween
         ) {
             Image(
-                painter = painterResource(id = item.avatarRes),
+                painter = painterResource(id = R.drawable.ic_dragon_logo),
                 contentDescription = item.name,
                 modifier = Modifier.size(72.dp)
             )
@@ -226,5 +211,12 @@ private fun CharacterCard(item: CharacterCardUi) {
 @Preview(showBackground = true)
 @Composable
 private fun PreviewMainScreen() {
-    LairSheetTheme { MainScreen() }
+    LairSheetTheme {
+        MainScreen(
+            ruleset = Ruleset.R5E_2014,
+            characters = emptyList(),
+            onRulesetChange = {},
+            onCreateCharacter = {}
+        )
+    }
 }

--- a/app/src/main/java/com/example/lairsheet/ui/theme/SplashScreen.kt
+++ b/app/src/main/java/com/example/lairsheet/ui/theme/SplashScreen.kt
@@ -1,0 +1,39 @@
+package com.example.lairsheet.ui.theme
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.lairsheet.R
+
+@Composable
+fun SplashScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(LightPink),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_dragon_logo),
+                contentDescription = "Логотип",
+                modifier = Modifier.size(128.dp)
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = "Lair Sheet",
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+                color = DeepRed
+            )
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.8.0"
 composeBom = "2024.09.00"
+room = "2.6.1"
+ksp = "2.0.21-1.0.25"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -15,6 +17,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
@@ -24,9 +27,13 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 


### PR DESCRIPTION
## Summary
- show a splash screen before opening the main screen
- create and store characters in a Room database with rule-set filtering
- fix build by adding lifecycle ViewModel Compose dependency

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fb2eec45c832ab5332116845bec7a